### PR TITLE
Stop treating warnings as errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install and build
       run: |
         yarn install --frozen-lockfile
-        yarn build        
+        CI=false yarn build        
 
     # Deployment
     - name: Deploy to GitHub Pages

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Grid, makeStyles, Typography } from '@material-ui/core';
+import { Grid, makeStyles } from '@material-ui/core';
 import { Label } from './Label';
 import { mdiGithub, mdiLinkedin, mdiDeviantart } from '@mdi/js';
 

--- a/src/components/Label.jsx
+++ b/src/components/Label.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Grid, Typography, makeStyles, Button } from '@material-ui/core';
-import { Link } from 'react-router-dom';
 import Icon from '@mdi/react';
 
 const useStyles = makeStyles({


### PR DESCRIPTION
Warnings are treated as errors when building `gh-pages` from the `development` branch, but given that most - if not all - warnings will be from unused imports, it seems silly to cause the build to fail on that alone.

So, this PR changes `yarn build` to `CI=false yarn build`.